### PR TITLE
Add New Plugin (Fractal Carriers)

### DIFF
--- a/plugins/fractal_carriers.xml
+++ b/plugins/fractal_carriers.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin name="Fractal Carriers">
+ <author>Zoura3025</author>
+ <license>GPLv3+</license>
+ <git>https://github.com/AvianGeneticist/fractalcarrier</git>
+</plugin>


### PR DESCRIPTION
This adds a couple new outfits and a new ship to the game, all relating to a Za'lek bay-based drone that can produce and launch its own drones.

Suspected incompability with the "Auxiliary Bay" plugin, as they both edit the Za'lek Medium Outfits list.

Plugin has been tested; all features should work.