### PR TITLE
Add Big Largeness Plugin

### DIFF
--- a/plugins/big_largeness.xml
+++ b/plugins/big_largeness.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin name="Big Largeness">
+ <author>Zoura3025</author>
+ <license>GPLv3+</license>
+ <git>https://github.com/AvianGeneticist/biglargeness</git>
+</plugin>


### PR DESCRIPTION
A plugin with a slightly silly name that adds some enlarged Structural Outfits, Core Systems, and Engines to the game. Also adds enlarged Za'lek bays.

Plugin is tested and working correctly; all outfits are obtainable and I haven't run into any crashes.